### PR TITLE
Fixes permission errors for automatic upgrade.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ RUN mkdir -p /go/src/github.com/syncthing && \
 ADD start.sh /start.sh
 RUN chmod +x /start.sh
 
-RUN useradd -m syncthing
+RUN useradd -m syncthing && \
+    mv /syncthing /home/syncthing/syncthing && \
+    chown syncthing:syncthing /home/syncthing/syncthing
 WORKDIR /home/syncthing
 
 VOLUME ["/home/syncthing/.config/syncthing", "/home/syncthing/Sync"]

--- a/start.sh
+++ b/start.sh
@@ -7,10 +7,10 @@ CONFIG_FOLDER="$HOME/.config/syncthing"
 CONFIG_FILE="$CONFIG_FOLDER/config.xml"
 
 if [ ! -f "$CONFIG_FILE" ]; then
-    /syncthing -generate="$CONFIG_FOLDER"
+    $HOME/syncthing -generate="$CONFIG_FOLDER"
     xmlstarlet ed -L -u "/configuration/gui/address" -v "0.0.0.0:8080" "$CONFIG_FILE"
 fi
 
 chown -R syncthing:syncthing "$HOME"
 
-exec su - syncthing -c /syncthing
+exec su - syncthing -c $HOME/syncthing


### PR DESCRIPTION
Moves the syncthing binary from / to /home/syncthing/ and changes ownership to the syncthing user.

Without this, I would get an error message that the automatic upgrade failed due to not being able to write to the same directory as the syncthing binary. 
