### PR TITLE
update README.md to reflect docker file port changes. Fixes #4

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ istepanov/syncthing
     docker run -d \
         --name syncthing \
         --restart always \
-        -p 8384:8384 -p 22000:22000 -p 21025:21025/udp \
+        -p 8384:8384 -p 22000:22000 -p 21027:21027/udp \
         -v /opt/docker/syncthing/config:/home/syncthing/.config/syncthing \
         -v /opt/docker/syncthing/Sync:/home/syncthing/Sync \
         istepanov/syncthing


### PR DESCRIPTION
Brings README.md back in line with the Dockerfile for port info since pr #3 was merged.

Thanks for your work on this docker image.
